### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <maintainer email="adrien.guichard@citel.fr">Adrien GUICHARD</maintainer>
 
-  <license file="LICENSE">GPLv2</license>
+  <license file="LICENSE">GPL-2.0-or-later</license>
 
   <url branch="main" type="repository">https://github.com/Taack/taack-plm-freecad</url>
 


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `GPL-2.0-only`, in which case use that instead.
